### PR TITLE
Make repo into proper module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module Network-go
+module github.com/TTK4145/Network-go
 
 go 1.16

--- a/main.go
+++ b/main.go
@@ -1,18 +1,19 @@
 package main
 
 import (
-	"Network-go/network/bcast"
-	"Network-go/network/localip"
-	"Network-go/network/peers"
 	"flag"
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/TTK4145/Network-go/network/bcast"
+	"github.com/TTK4145/Network-go/network/localip"
+	"github.com/TTK4145/Network-go/network/peers"
 )
 
 // We define some custom struct to send over the network.
-// Note that all members we want to transmit must be public. Any private members
-//  will be received as zero-values.
+// Note that all members we want to transmit must be public.
+// Any private members will be received as zero-values.
 type HelloMsg struct {
 	Message string
 	Iter    int

--- a/network/bcast/bcast.go
+++ b/network/bcast/bcast.go
@@ -1,11 +1,12 @@
 package bcast
 
 import (
-	"Network-go/network/conn"
 	"encoding/json"
 	"fmt"
 	"net"
 	"reflect"
+
+	"github.com/TTK4145/Network-go/network/conn"
 )
 
 const bufSize = 1024
@@ -34,13 +35,13 @@ func Transmitter(port int, chans ...interface{}) {
 			JSON:   jsonstr,
 		})
 		if len(ttj) > bufSize {
-		    panic(fmt.Sprintf(
-		        "Tried to send a message longer than the buffer size (length: %d, buffer size: %d)\n\t'%s'\n"+
-		        "Either send smaller packets, or go to network/bcast/bcast.go and increase the buffer size",
-		        len(ttj), bufSize, string(ttj)))
+			panic(fmt.Sprintf(
+				"Tried to send a message longer than the buffer size (length: %d, buffer size: %d)\n\t'%s'\n"+
+					"Either send smaller packets, or go to network/bcast/bcast.go and increase the buffer size",
+				len(ttj), bufSize, string(ttj)))
 		}
 		conn.WriteTo(ttj, addr)
-    		
+
 	}
 }
 
@@ -83,12 +84,14 @@ type typeTaggedJSON struct {
 }
 
 // Checks that args to Tx'er/Rx'er are valid:
-//  All args must be channels
-//  Element types of channels must be encodable with JSON
-//  No element types are repeated
+//
+//	All args must be channels
+//	Element types of channels must be encodable with JSON
+//	No element types are repeated
+//
 // Implementation note:
-//  - Why there is no `isMarshalable()` function in encoding/json is a mystery,
-//    so the tests on element type are hand-copied from `encoding/json/encode.go`
+//   - Why there is no `isMarshalable()` function in encoding/json is a mystery,
+//     so the tests on element type are hand-copied from `encoding/json/encode.go`
 func checkArgs(chans ...interface{}) {
 	n := 0
 	for range chans {
@@ -117,13 +120,12 @@ func checkArgs(chans ...interface{}) {
 		elemTypes[i] = elemType
 
 		// Element type must be encodable with JSON
-		checkTypeRecursive(elemType, []int{i+1})
+		checkTypeRecursive(elemType, []int{i + 1})
 
 	}
 }
 
-
-func checkTypeRecursive(val reflect.Type, offsets []int){
+func checkTypeRecursive(val reflect.Type, offsets []int) {
 	switch val.Kind() {
 	case reflect.Complex64, reflect.Complex128, reflect.Chan, reflect.Func, reflect.UnsafePointer:
 		panic(fmt.Sprintf(

--- a/network/peers/peers.go
+++ b/network/peers/peers.go
@@ -1,11 +1,12 @@
 package peers
 
 import (
-	"Network-go/network/conn"
 	"fmt"
 	"net"
 	"sort"
 	"time"
+
+	"github.com/TTK4145/Network-go/network/conn"
 )
 
 type PeerUpdate struct {


### PR DESCRIPTION
This makes it possible to run
```shell
go get github.com/TTK4145/Network-go
```

It will no longer be necessary to download files
from ./network locally.

Changes also include some small refactoring.